### PR TITLE
Fixes/do not send emails to disabled users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,10 +3,12 @@ class User < ActiveRecord::Base
 
   has_many :entries
 
+  scope :active, -> { where(state: "active") }
+
   def self.send_reminders
     return if Date.today.saturday? || Date.today.sunday? || holiday?
 
-    User.all.each do |user|
+    User.active.each do |user|
       if user.entries.today.count == 0
         Reminder.send_to(user).deliver
       end
@@ -14,7 +16,7 @@ class User < ActiveRecord::Base
   end
 
   private
-  
+
   def self.holiday?
     ENV["COUNTRY_CODE"] && Holidays.on(Date.today, ENV["COUNTRY_CODE"]).any?
   end

--- a/app/services/freckle_service.rb
+++ b/app/services/freckle_service.rb
@@ -1,13 +1,27 @@
 require "freckle"
 
 class FreckleService
-  attr_reader :client
 
-  def initialize
+  def self.client
     @client ||= Freckle::Client.new(token: ENV["FRECKLE_TOKEN"])
   end
 
-  def import_entries(start_date, end_date)
+  def self.import_users
+    client.get_users.each do |user|
+      u = User.find_or_create_by(id: user.id)
+      u.update_attributes(name: "#{user.first_name} #{user.last_name}",
+                          email: user.email, state: user.state)
+    end
+  end
+
+  def self.import_projects
+    client.get_projects.each do |project|
+      p1 = Project.find_or_create_by(id: project.id)
+      p1.update_attributes(name: project.name, enabled: project.enabled)
+    end
+  end
+
+  def self.import_entries(start_date, end_date)
     result = client.get_entries(from: start_date, to: end_date)
     save_entries_for(result)
 
@@ -22,7 +36,7 @@ class FreckleService
 
   private
 
-  def save_entries_for(result)
+  def self.save_entries_for(result)
     result.each do |entry|
       e1 = Entry.find_or_create_by(id: entry.id)
       e1.update_columns(

--- a/db/migrate/20160421164622_add_state_to_user.rb
+++ b/db/migrate/20160421164622_add_state_to_user.rb
@@ -1,0 +1,5 @@
+class AddStateToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :state, :string
+  end
+end

--- a/db/migrate/20160421164630_add_enabled_to_project.rb
+++ b/db/migrate/20160421164630_add_enabled_to_project.rb
@@ -1,0 +1,5 @@
+class AddEnabledToProject < ActiveRecord::Migration
+  def change
+    add_column :projects, :enabled, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150716202854) do
+ActiveRecord::Schema.define(version: 20160421164630) do
 
   create_table "entries", force: :cascade do |t|
     t.text     "description"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 20150716202854) do
     t.string   "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean  "enabled"
   end
 
   create_table "user_leaderboards", force: :cascade do |t|
@@ -52,6 +53,7 @@ ActiveRecord::Schema.define(version: 20150716202854) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string   "email"
+    t.string   "state"
   end
 
 end

--- a/lib/tasks/importer.rake
+++ b/lib/tasks/importer.rake
@@ -1,22 +1,11 @@
 namespace :import do
 
-  def freckle_service
-    FreckleService.new
-  end
-
   task users: :environment do
-    freckle_service.client.get_users.each do |user|
-      u = User.find_or_create_by(id: user.id)
-      u.update_columns(name: "#{user.first_name} #{user.last_name}",
-                       email: user.email)
-    end
+    FreckleService.import_users
   end
 
   task projects: :environment do
-    freckle_service.client.get_projects.each do |project|
-      p1 = Project.find_or_create_by(id: project.id)
-      p1.update_columns(name: project.name)
-    end
+    FreckleService.import_projects
   end
 
   desc "Import new Freckle entries"
@@ -26,7 +15,7 @@ namespace :import do
 
     puts "start importing entries from #{start_date} to #{end_date}"
 
-    freckle_service.import_entries(start_date, end_date)
+    FreckleService.import_entries(start_date, end_date)
 
     puts 'finished importing entries'
   end

--- a/spec/factories/project.rb
+++ b/spec/factories/project.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :project do
     sequence(:name) {|n| "project_#{n}"}
+    enabled { true }
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -2,5 +2,6 @@ FactoryGirl.define do
   factory :user do
     sequence(:name) {|n| "name_#{n}"}
     sequence(:email) {|n| "name_#{n}@example.com"}
+    state { "active" }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -76,6 +76,18 @@ describe User do
         User.send_reminders
       end
     end
+
+    context 'disabled user' do
+      let(:user) do
+        create(:user, name: 'foo', email: 'bar@example.com', state: "disabled")
+      end
+
+      it 'should not send reminder to user with an entry' do
+        expect(Reminder).not_to receive(:send_to).with(user)
+
+        User.send_reminders
+      end
+    end
   end
 
   describe '#minutes_of_current_week' do

--- a/spec/services/freckle_client_spec.rb
+++ b/spec/services/freckle_client_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 describe FreckleService do
-  subject { described_class.new }
   before do
     stub_const("ENV", {"FRECKLE_TOKEN" => "foobar"})
   end
@@ -12,19 +11,19 @@ describe FreckleService do
 
     context "without any new entries" do
       before do
-        allow(subject.client).to receive(:get_entries).and_return([])
+        allow(described_class.client).to receive(:get_entries).and_return([])
       end
 
       it "doesn't create any entries in the database" do
         expect do
-          subject.import_entries(start_date, end_date)
+          described_class.import_entries(start_date, end_date)
         end.to change(Entry, :count).by(0)
       end
     end
 
     context "with new entries" do
-      let(:freckle_user) { double("Freckle::User", id: 1) }
-      let(:freckle_project) { double("Freckle::Project", id: 1) }
+      let(:freckle_user) { double("Freckle::User", id: 1, state: "active") }
+      let(:freckle_project) { double("Freckle::Project", id: 1, enabled: true) }
       let(:freckle_entry) do
         double("Freckle::Entry", id: 1, description: "Hello!", minutes: 60,
                                  date: Time.zone.now, user: freckle_user,
@@ -32,13 +31,13 @@ describe FreckleService do
       end
 
       before do
-        allow(subject.client).to(
+        allow(described_class.client).to(
           receive(:get_entries).and_return([freckle_entry]))
       end
 
       it "creates the new entries in the database" do
         expect do
-          subject.import_entries(start_date, end_date)
+          described_class.import_entries(start_date, end_date)
         end.to change(Entry, :count).by(1)
 
         entry = Entry.last
@@ -48,11 +47,11 @@ describe FreckleService do
 
       it "doesn't create entries again if they already exist" do
         expect do
-          subject.import_entries(start_date, end_date)
+          described_class.import_entries(start_date, end_date)
         end.to change(Entry, :count).by(1)
 
         expect do
-          subject.import_entries(start_date, end_date)
+          described_class.import_entries(start_date, end_date)
         end.to change(Entry, :count).by(0)
       end
     end


### PR DESCRIPTION
Hey @etagwerker, @schmierkov, 

This PR makes it so that emails are only sent to "active" users. Also refactored some stuff to move logic from the Rake task to `FreckleService`. 

Please check it out, thanks! 