### PR TITLE
Fixes API pagination of imported entries.

### DIFF
--- a/app/services/freckle_service.rb
+++ b/app/services/freckle_service.rb
@@ -27,8 +27,7 @@ class FreckleService
 
     if last = result.try(:link).try(:last)
       last_page = last.match(/page=(\d+)/)[1].to_i
-      pages = (2..last_page)
-      pages.each do |page|
+      (2..last_page).each do |page|
         result = client.get_entries(from: start_date, to: end_date, page: page)
         save_entries_for(result)
       end

--- a/app/services/freckle_service.rb
+++ b/app/services/freckle_service.rb
@@ -25,9 +25,10 @@ class FreckleService
     result = client.get_entries(from: start_date, to: end_date)
     save_entries_for(result)
 
-    if result.try(:last_page)
-      last_page = result.last_page.match(/page=(\d+)/)[1].to_i
-      [2..last_page].each do |page|
+    if last = result.try(:link).try(:last)
+      last_page = last.match(/page=(\d+)/)[1].to_i
+      pages = (2..last_page)
+      pages.each do |page|
         result = client.get_entries(from: start_date, to: end_date, page: page)
         save_entries_for(result)
       end


### PR DESCRIPTION
Hey @etagwerker, @schmierkov, 

This PR fixes the import of entries and adds some coverage, we were only retrieving the first page of results, at some point we were using a branch instead of the latest version, see: https://github.com/timcraft/freckles/pull/1. We're now using the solution in https://github.com/timcraft/freckles/pull/1#issuecomment-196798160. 

Please check it out, thanks! 