### PR TITLE
Fix bug with deploying to heroku when an entry exists with no project

### DIFF
--- a/app/services/noko_service.rb
+++ b/app/services/noko_service.rb
@@ -22,7 +22,7 @@ class NokoService
   end
 
   def self.import_entries(start_date, end_date)
-    result = client.get_entries(from: start_date, to: end_date)
+    result = client.get_entries(from: start_date, to: end_date, per_page: 1000)
     missing_projects = []
     save_entries_for(result, missing_projects)
 

--- a/app/services/noko_service.rb
+++ b/app/services/noko_service.rb
@@ -29,12 +29,12 @@ class NokoService
     if last = result.try(:link).try(:last)
       last_page = last.match(/page=(\d+)/)[1].to_i
       (2..last_page).each do |page|
-        result = client.get_entries(from: start_date, to: end_date, page: page)
+        result = client.get_entries(from: start_date, to: end_date, per_page: 1000)
         save_entries_for(result, missing_projects)
       end
     end
     if missing_projects.present?
-      puts "The following time entries must be updated before import: "
+      puts "The following time entries are missing a project. They must be updated before import: "
       missing_projects.each{ |missing| puts missing }
     end
 end


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/168900055

When a user adds a time entry to Noko and forgets to tag it with a project, it blocks the rake task and Pecas cannot upload that time entry to time.ombulabs.com. 

<img width="1083" alt="Screen Shot 2019-10-04 at 2 46 57 PM" src="https://user-images.githubusercontent.com/28606034/66228456-d8aa0180-e6b5-11e9-972d-ffd743065f04.png">
